### PR TITLE
fix usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ $ go get -u -v github.com/gobuffalo/buffalo-docker
 ## Usage
 
 ```bash
-$ buffalo docker --help
+$ buffalo-docker --help
 ```


### PR DESCRIPTION
Unless I did something wrong, I installed `buffalo-docker` with `go get -u -v github.com/gobuffalo/buffalo-docker`, but when trying to run `docker` as a subcommand of `buffalo` I get:

```
$ buffalo docker
ERRO[0002] Error: unknown command "docker" for "buffalo"
```

Running as `buffalo-docker` though works just fine. 