### PR TITLE
Typo in Dockerfile

### DIFF
--- a/genny/docker/templates/multi/Dockerfile.tmpl
+++ b/genny/docker/templates/multi/Dockerfile.tmpl
@@ -21,7 +21,7 @@ ADD . .
 RUN dep ensure
 {{else -}}
 {{if .opts.App.WithModules -}}
-ENV GO111MODULES=on
+ENV GO111MODULE=on
 {{end -}}
 RUN go get ./...
 {{end -}}


### PR DESCRIPTION
in the multi stage dockerfile, `GO111MODULES=on` is used - this isn't the right variable, it should be `GO111MODULE=on`.  This was causing me problems - this should fix that.